### PR TITLE
feat(trdl): support trdl in all main multiwerf commands, rework flags

### DIFF
--- a/pkg/multiwerf/multiwerf.go
+++ b/pkg/multiwerf/multiwerf.go
@@ -30,6 +30,7 @@ type UpdateOptions struct {
 	WithGC                  bool
 	OutputFile              string
 	TryTrdl                 bool
+	AutoInstallTrdl         bool
 }
 
 // Update checks for the actual version for group/channel and downloads it to StorageDir if it does not already exist
@@ -145,6 +146,7 @@ type UseOptions struct {
 	TryRemoteChannelMapping bool
 	WithGC                  bool
 	TryTrdl                 bool
+	AutoInstallTrdl         bool
 }
 
 // Use:


### PR DESCRIPTION
* Multiwerf werf-path and exec commands will try to use trdl.
    * Only in the case when trdl has been downloaded and installed by the multiwerf update or multiwerf use commands.
        * This behavior confirms with werf-path and exec commands behaviour, which will complain if werf has not been installed yet.
* --try-trdl='yes|no' flag enables or disables usage of trdl.
* --auto-download-trdl='yes|no|on-self-update(default)' flag controls whether multiwerf will try to install trdl if it is not installed in the system yet.
    * By default multiwerf will auto install trdl unless --self-update=no flag is set.
        * User can force auto install of trdl in that case by an explicit --auto-download-trdl=yes option.